### PR TITLE
trajectory_controller_dirty_fix

### DIFF
--- a/include/youbot_driver_ros_interface/YouBotOODLWrapper.h
+++ b/include/youbot_driver_ros_interface/YouBotOODLWrapper.h
@@ -282,6 +282,8 @@ private:
     bool areBaseMotorsSwitchedOn;
     bool areArmMotorsSwitchedOn;
 
+    std::vector<youbot::JointAngleSetpoint> desiredTrajectoryGoal;
+
     ros::Time last_gripper_readings_time_;
 };
 


### PR DESCRIPTION
accurately reach to the goal configuration

Problem: Under trajectory control, the joints do not reach to final
         goal configuration due to inaccurately tuned pid-gains or low
         joint speeds for last trajectory points.

Temporary fix:
         Extract joint positions from the last trajectory point. When
         the trajectory controller is done then send the joint positions
         from the last trajectory point to the joint position controller.
