### PR TITLE
[CMakeList] Don't use gksudo and opt into sudo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,13 +38,9 @@ install(DIRECTORY launch/
 
 ## run sudo command to enable direct network access
 ## disabled here by default because it is set by Debian postinst command
+option(${PROJECT_NAME}_USE_SETCAP "Set permissions to access ethernet interface without sudo" OFF)
 
-option(${PROJECT_NAME}_USE_SETCAP "Set permissions to access ethernet interface without sudo" ON)
-
-set(SUDO_COMMAND gksudo)
-if($ENV{USE_NORMAL_SUDO})
-    set(SUDO_COMMAND sudo)
-endif()
+set(SUDO_COMMAND sudo)
 
 if(${PROJECT_NAME}_USE_SETCAP)
     add_custom_command(TARGET youbot_driver_ros_interface POST_BUILD


### PR DESCRIPTION
1. As the comment in the CMakeLists one line above said, it should be disabled
by default because it is part of the debian post install instructions.

2. Don't use gksudo at all, just use normal sudo. gksudo doesn't seem to be available
in future releases of Ubuntu.