### PR TITLE
update: gksu has been deprecated, replaced with pkexec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ install(DIRECTORY launch/
 
 option(${PROJECT_NAME}_USE_SETCAP "Set permissions to access ethernet interface without sudo" ON)
 
-set(SUDO_COMMAND gksudo)
+set(SUDO_COMMAND pkexec)
 if($ENV{USE_NORMAL_SUDO})
     set(SUDO_COMMAND sudo)
 endif()


### PR DESCRIPTION
If an error pops up, replace `pkexec` with `sudo -H` (Note: Windows Subsystem for Linux 2(WSL2)+Ubuntu 20.04 shows up error with `pkexec`)

 - `pkexec` asks for user password while building the package (GUI based)
 - `sudo -H` asks for a password on the terminal

Reference: https://askubuntu.com/a/1192202/922137